### PR TITLE
Update Tags.gitignore

### DIFF
--- a/Global/Tags.gitignore
+++ b/Global/Tags.gitignore
@@ -1,7 +1,9 @@
 # Ignore tags created by etags, ctags, gtags (GNU global) and cscope
 TAGS
+.TAGS
 !TAGS/
 tags
+.tags
 !tags/
 gtags.files
 GTAGS


### PR DESCRIPTION
Updated the tags ignore to include the .tags file. The main reason behind this is because Atom's symbols-view (https://atom.io/packages/symbols-view) supports tags/.tags/TAGS/.TAGS. Therefore, I thought it was a good idea to add the .tags/.TAGS to the ignore list.
